### PR TITLE
Recompose mask tests

### DIFF
--- a/talos/compounds/tests/conftest.py
+++ b/talos/compounds/tests/conftest.py
@@ -15,4 +15,7 @@ def mask():
 
 @pytest.fixture(scope='session')
 def masked_inputs(inputs):
-    return tf.keras.layers.Masking()(inputs)
+    outputs = tf.keras.layers.Masking()(inputs)
+    # don't change this part!!!!
+    assert isinstance(outputs._keras_mask, tf.Tensor)
+    return outputs

--- a/talos/compounds/tests/test_attention.py
+++ b/talos/compounds/tests/test_attention.py
@@ -31,10 +31,11 @@ def test_raise_invalid_input_rank(invalid_inputs, layer):
 
 def test_masked_inputs_propagate(mocker, masked_inputs, layer):
     # since keras use func inspect, directly mock layer.call will cause side effect
+    assert isinstance(masked_inputs._keras_mask, tf.Tensor)
     mock_cast = mocker.spy(tf, 'cast')  # would call if mask is passed
     outputs = layer(masked_inputs)
     assert mock_cast.called
-    assert outputs._keras_mask is not None
+    assert outputs._keras_mask is masked_inputs._keras_mask
 
 
 def test_mask_gradients(inputs, mask, layer, sess):

--- a/talos/compounds/tests/test_transformer_block.py
+++ b/talos/compounds/tests/test_transformer_block.py
@@ -18,7 +18,7 @@ def test_output_shape(inputs, layer):
 
 def test_masked_inputs_propagate(masked_inputs, layer):
     outputs = layer(masked_inputs)
-    assert outputs._keras_mask is not None
+    assert outputs._keras_mask is masked_inputs._keras_mask
 
 
 def test_mask_gradients(inputs, mask, layer, sess):

--- a/talos/networks/tests/test_sequential.py
+++ b/talos/networks/tests/test_sequential.py
@@ -53,11 +53,12 @@ def test_mask_given_in_inputs_propagate():
         tf.keras.layers.Dense(5),
     ])
     assert all(layer.supports_masking for layer in sequential_supports_mask.layers)
+    mask = tf.ones([5, 4], dtype=tf.bool)
     outputs = sequential_supports_mask(
         tf.ones([5, 4, 3]),
-        mask=tf.ones([5, 4], dtype=tf.bool),
+        mask=mask,
     )
-    assert outputs._keras_mask is not None
+    assert outputs._keras_mask is mask  # since Dense simply pass it.
 
 
 def test_masked_inputs_propagate():
@@ -68,4 +69,4 @@ def test_masked_inputs_propagate():
     ])
     assert all(layer.supports_masking for layer in sequential_supports_mask.layers)
     outputs = sequential_supports_mask(masked_inputs)
-    assert outputs._keras_mask is not None
+    assert outputs._keras_mask is masked_inputs._keras_mask


### PR DESCRIPTION
加測了 Sequential 對於 keras mask 的傳遞可能性

證實 Sequential 對於
1. 明確給入 arg 的 mask
2. input tensor 帶的 _keras_mask
3. 中間 layer 產生的 _keras_mask

都可以正確傳遞 (即 output._keras_mask is not None，如果所有 layer 都 supports_masking)，

而其他 Layer 則是 (使用是指 call 裡面若有宣告 mask arg signature，可以計算正確結果)
1. 可以使用但不能傳遞 明確給入 arg 的 mask
2. 可以使用並傳遞 input tensor 帶的 _keras_mask

以上確定成立的特性，目前都有測試包含，
並把 compounds 內重複側的部分拔了 (Sequential 測過)
此外，組織了更多 fixture 

