### PR TITLE
More LayerNorm

### DIFF
--- a/talos/layers/layer_norm.py
+++ b/talos/layers/layer_norm.py
@@ -7,25 +7,29 @@ class LayerNormalization(tf.keras.layers.Layer):
             self,
             center: bool = True,
             scale: bool = True,
-            trainable: bool = True,
-            axis: int = -1,
+            beta_initializer: str = 'zeros',
+            gamma_initializer: str = 'ones',
             **kwargs,
         ):
         super().__init__(**kwargs)
         self.center = center
         self.scale = scale
-        self.trainable = trainable
-        self.axis = axis
+        self.beta_initializer = beta_initializer
+        self.gamma_initializer = gamma_initializer
         self.supports_masking = True
 
     def build(self, input_shape):
         # Create a trainable weight variable for this layer.
+        if (self.center or self.scale) and input_shape[-1].value is None:
+            raise ValueError(
+                f'The last dimension of the inputs to `LayerNormalization` '
+                'should be defined. Found `None`.',
+            )
         if self.center:
             self.beta = self.add_weight(
                 name='beta',
-                shape=input_shape[self.axis],
-                initializer='zeros',
-                trainable=self.trainable,
+                shape=[input_shape[-1].value],
+                initializer=self.beta_initializer,
             )
         else:
             self.beta = None
@@ -33,17 +37,21 @@ class LayerNormalization(tf.keras.layers.Layer):
         if self.scale:
             self.gamma = self.add_weight(
                 name='gamma',
-                shape=input_shape[self.axis],
-                initializer='ones',
-                trainable=self.trainable,
+                shape=[input_shape[-1].value],
+                initializer=self.gamma_initializer,
             )
         else:
             self.gamma = None
 
+        if self.center or self.scale:
+            self.input_spec = tf.keras.layers.InputSpec(axes={
+                -1: input_shape[-1].value,
+            })
+
         super().build(input_shape)
 
     def call(self, inputs):
-        mean, variance = tf.nn.moments(inputs, axes=[self.axis], keep_dims=True)
+        mean, variance = tf.nn.moments(inputs, axes=[-1], keep_dims=True)
         return tf.nn.batch_normalization(
             inputs,
             mean=mean,

--- a/talos/layers/tests/test_layer_norm.py
+++ b/talos/layers/tests/test_layer_norm.py
@@ -11,20 +11,59 @@ def layer():
     return LayerNormalization()
 
 
-def test_output_shape(layer):
-    shape = [3, 5]
-    assert layer(tf.zeros(shape)).shape.as_list() == shape
+@pytest.fixture(scope='module', params=[
+    tf.zeros([3, 5]),
+    tf.zeros([3, 4, 5]),
+])
+def inputs(request):
+    return request.param
 
 
-def test_output_value(layer, sess):
-    inputs = tf.constant([[1., 2., 3.], [4., 5., 6.]])
+def test_output_shape(layer, inputs):
+    outputs = layer(inputs)
+    assert outputs.shape.as_list() == inputs.shape.as_list()
+    assert layer.compute_output_shape(inputs.shape) == inputs.shape.as_list()
+
+
+def test_no_variable_input_spec_without_scale_and_center(inputs):
+    layer = LayerNormalization(scale=False, center=False)
+    layer(inputs)
+    assert len(layer.variables) == 0
+    assert layer.input_spec is None
+
+
+def test_variables_input_spec_with_scale_and_center(layer, inputs, sess):
+    layer(inputs)
+    assert len(layer.variables) == len(layer.trainable_variables) == 2
+
+    input_dim = inputs.shape[-1].value
+    assert layer.beta.shape.as_list() == [input_dim]
+    assert layer.gamma.shape.as_list() == [input_dim]
+
+    sess.run(tf.variables_initializer(var_list=layer.variables))
+    assert (sess.run(layer.beta) == 0.).all()  # default initializer
+    assert (sess.run(layer.gamma) == 1.).all()  # default initializer
+    assert layer.input_spec.axes == {-1: input_dim}
+
+
+@pytest.mark.parametrize('input_val', [
+    np.array([[1, 2, 3], [4, 5, 6]]),
+])
+def test_output_value(input_val, sess):
+    layer = LayerNormalization(
+        beta_initializer=tf.random_normal_initializer(),
+        gamma_initializer=tf.random_normal_initializer(),
+    )
+    inputs = tf.constant(input_val, dtype=tf.float32)
     outputs = layer(inputs)
 
     sess.run(tf.variables_initializer(var_list=layer.variables))
+
+    output_val, beta, gamma = sess.run([outputs, layer.beta, layer.gamma])
+    mean = np.mean(input_val, axis=1, keepdims=True)
+    std = np.std(input_val, axis=1, keepdims=True)
+    expected_output_val = gamma * (input_val - mean) / std + beta
     np.testing.assert_array_almost_equal(
-        sess.run(outputs),
-        np.array([
-            [-np.sqrt(1.5), 0., np.sqrt(1.5)],
-            [-np.sqrt(1.5), 0., np.sqrt(1.5)],
-        ]),
+        output_val,
+        expected_output_val,
     )


### PR DESCRIPTION
把 LayerNormalization 的 axis 拿掉了

因為如果不是 -1 ， call tf.nn.batch_normalization 的時候會 broadcast 失敗
所以就寫死是 -1 了

此外，gamma / beta 目前寫死是最後一維的 scale 和 shift (也就是 shape = [input_shape[-1]])
但他其實是可以不只那維的 (例如 shape = input_shape[1:])

但我個人覺得在 transformer 上，每個 time step 用不同的 scale/shift 不會差多少
畢竟就意義上這只是為了適應 mean std 的影響，
每個 time step 用一樣的應該比較不會使後續 attention overfit，

tensor2tensor 也是實作成這樣

此外也補上更多測試

