### PR TITLE
use tf.linalg.matvec in spectral_norm to avoid redundant tf.squeeze

### DIFF
--- a/talos/spectral_norm/tests/test_spectral_norm.py
+++ b/talos/spectral_norm/tests/test_spectral_norm.py
@@ -44,7 +44,8 @@ def test_grad_value(sess):
 
     eps = tf.keras.backend.epsilon()
     # Formula Reference: https://hackmd.io/HHWrnmbWSXKb_DIFmHKtAA
-    expected_dW = (dW_sn_val - u * v[:, 0] * np.sum(W_sn_val * dW_sn_val)) / (sn_val + eps)
+    uv = u[:, np.newaxis] * v
+    expected_dW = (dW_sn_val - uv * np.sum(W_sn_val * dW_sn_val)) / (sn_val + eps)
     np.testing.assert_array_almost_equal(dW_val, expected_dW, decimal=4)
 
 


### PR DESCRIPTION
tf.linalg.matvec(x, y)
== tf.squeeze(tf.matmul(x, y[:, tf.newaxis]), axis=-1)

降低視覺雜訊