### PR TITLE
impl LookAhead wrapper

### DIFF
--- a/talos/optimizers/look_ahead.py
+++ b/talos/optimizers/look_ahead.py
@@ -1,0 +1,48 @@
+import tensorflow as tf
+
+
+class LookAhead(tf.train.Optimizer):
+
+    '''Reference: https://arxiv.org/abs/1907.08610'''
+
+    def __init__(
+            self,
+            optimizer: tf.train.Optimizer,
+            alpha: float = 0.5,
+            explore_step: int = 5,
+        ):
+        self.optimizer = optimizer
+        self.alpha = alpha
+        self.explore_step = explore_step
+        self.ema = tf.train.ExponentialMovingAverage(
+            decay=1. - alpha,
+            name="LookAheadSlowVariables",
+        )
+
+    def apply_gradients(self, grads_and_vars, global_step=None, name=None):
+        if global_step is None:
+            global_step = tf.train.get_or_create_global_step()  # initial 0
+
+        # global_step will be updated here
+        update_op = self.optimizer.apply_gradients(grads_and_vars, global_step=global_step)
+        var_list = [v for g, v in grads_and_vars if g is not None]
+
+        with tf.control_dependencies([update_op]):
+            finish_op = tf.cond(
+                tf.equal(
+                    tf.mod(global_step, self.explore_step),
+                    0,
+                ),
+                lambda: self._slow_fast_updates(var_list),
+                tf.no_op,
+                name=name,
+            )
+
+        return finish_op
+
+    def _slow_fast_updates(self, var_list):
+        with tf.control_dependencies([self.ema.apply(var_list)]):  # update slow
+            return tf.group(*[
+                var.assign(self.ema.average(var))  # synchronize fast by slow
+                for var in var_list
+            ])

--- a/talos/optimizers/look_ahead.py
+++ b/talos/optimizers/look_ahead.py
@@ -9,11 +9,11 @@ class LookAhead(tf.train.Optimizer):
             self,
             optimizer: tf.train.Optimizer,
             alpha: float = 0.5,
-            explore_step: int = 5,
+            explore_steps: int = 5,
         ):
         self.optimizer = optimizer
         self.alpha = alpha
-        self.explore_step = explore_step
+        self.explore_steps = explore_steps
         self.ema = tf.train.ExponentialMovingAverage(
             decay=1. - alpha,
             name="LookAheadSlowVariables",
@@ -30,7 +30,7 @@ class LookAhead(tf.train.Optimizer):
         with tf.control_dependencies([update_op]):
             finish_op = tf.cond(
                 tf.equal(
-                    tf.mod(global_step, self.explore_step),
+                    tf.mod(global_step, self.explore_steps),
                     0,
                 ),
                 lambda: self._slow_fast_updates(var_list),

--- a/talos/optimizers/radam.py
+++ b/talos/optimizers/radam.py
@@ -7,6 +7,7 @@ from tensorflow.python.training import training_ops
 
 
 class RAdamOptimizer(tf.train.AdamOptimizer):
+    '''Reference: https://arxiv.org/abs/1908.03265v1'''
 
     # Add-On: create steps variable.
     def _create_slots(self, var_list):

--- a/talos/optimizers/tests/test_look_ahead.py
+++ b/talos/optimizers/tests/test_look_ahead.py
@@ -6,27 +6,36 @@ from ..look_ahead import LookAhead
 
 def test_look_ahead(sess):
     alpha, lr = 0.2, 0.1
+    explore_steps = 5
+    slow_val, grad_val = 1., 2.
     opt = LookAhead(
         tf.train.GradientDescentOptimizer(lr),
-        alpha=0.2,
-        explore_step=5,
+        alpha=alpha,
+        explore_steps=explore_steps,
     )
     with tf.variable_scope('test_look_ahead'):
-        x = tf.Variable(1.)
-        update_x = opt.minimize(2 * x)  # constant grad 2
+        x = tf.Variable(slow_val)
+        update_x = opt.minimize(grad_val * x)  # constant grad
 
     sess.run(tf.variables_initializer(
         tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope='test_look_ahead'),
     ))
-    for _ in range(4):
+
+    for _ in range(5):
+        fast_val = slow_val
+        for _ in range(explore_steps - 1):
+            sess.run(update_x)
+            fast_val -= lr * grad_val
+
+        np.testing.assert_almost_equal(sess.run(x), fast_val)
+
         sess.run(update_x)
+        fast_val -= lr * grad_val
 
-    x_val = sess.run(x)
-    np.testing.assert_almost_equal(x_val, 1. - 4 * lr * 2)
-    sess.run(update_x)
-
-    x_val = sess.run(x)
-    np.testing.assert_almost_equal(
-        x_val,
-        1. * (1 - alpha) + (1. - 5 * lr * 2) * alpha,
-    )
+        # step % explore_steps == 0, fast interpolates with slow
+        x_val = sess.run(x)
+        np.testing.assert_almost_equal(
+            x_val,
+            slow_val * (1 - alpha) + fast_val * alpha,
+        )
+        slow_val = x_val

--- a/talos/optimizers/tests/test_look_ahead.py
+++ b/talos/optimizers/tests/test_look_ahead.py
@@ -1,0 +1,32 @@
+import numpy as np
+import tensorflow as tf
+
+from ..look_ahead import LookAhead
+
+
+def test_look_ahead(sess):
+    alpha, lr = 0.2, 0.1
+    opt = LookAhead(
+        tf.train.GradientDescentOptimizer(lr),
+        alpha=0.2,
+        explore_step=5,
+    )
+    with tf.variable_scope('test_look_ahead'):
+        x = tf.Variable(1.)
+        update_x = opt.minimize(2 * x)  # constant grad 2
+
+    sess.run(tf.variables_initializer(
+        tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope='test_look_ahead'),
+    ))
+    for _ in range(4):
+        sess.run(update_x)
+
+    x_val = sess.run(x)
+    np.testing.assert_almost_equal(x_val, 1. - 4 * lr * 2)
+    sess.run(update_x)
+
+    x_val = sess.run(x)
+    np.testing.assert_almost_equal(
+        x_val,
+        1. * (1 - alpha) + (1. - 5 * lr * 2) * alpha,
+    )

--- a/talos/optimizers/tests/test_radam.py
+++ b/talos/optimizers/tests/test_radam.py
@@ -5,7 +5,8 @@ from ..radam import RAdamOptimizer
 
 
 def test_radam(sess):
-    radam_opt = RAdamOptimizer(0.1)
+    lr = 0.1
+    radam_opt = RAdamOptimizer(lr)
     with tf.variable_scope('test_radam'):
         x = tf.Variable(1.)
         update_x = radam_opt.minimize(2 * x)  # constant grad 2
@@ -17,12 +18,12 @@ def test_radam(sess):
         sess.run(update_x)
 
     x_val = sess.run(x)
-    np.testing.assert_almost_equal(x_val, 1. - 4 * 0.1 * 2)  # without adaptive gradient
+    np.testing.assert_almost_equal(x_val, 1. - 4 * lr * 2)  # without adaptive gradient
 
     # N_sma > 4 now
     rectifier, _ = sess.run([radam_opt.rectifier, update_x])
     new_x_val = sess.run(x)
     np.testing.assert_almost_equal(
         new_x_val,
-        x_val - 0.1 * rectifier * 2 / 2,  # with adaptive gradient: divide by sqrt(v)
+        x_val - lr * rectifier * 2 / 2,  # with adaptive gradient: divide by sqrt(v)
     )


### PR DESCRIPTION
LookAhead: https://arxiv.org/abs/1907.08610

實作成 Wrapper，並也擁有 tf.train.Optimizer 的介面

用 [`tf.train.ExponentialMovingAverage` ](https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage)
來實作更新的邏輯
fast 用本來的 variables，slow 用 EMA 做的複製來放

paper 裡面 fast 先 assign 到 slow 上的部分 (在 t 迴圈的開始， k 迴圈前)
被我換到前一個 t 迴圈的底部
因為 ema.apply 要先做才會產生 slow variables ，如果放在前面此時會沒東西可以 assign
如果先 apply 那 tf.cond 的 dependencies 則會錯誤

EMA 使用在 Variable 上的時候，會使用一樣的初始化，不會從 0 開始